### PR TITLE
Migrate/packages

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -194,7 +194,7 @@ packages:
       name: flutter_hooks
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.18.2+1"
+    version: "0.18.5+1"
   flutter_lints:
     dependency: transitive
     description:
@@ -508,4 +508,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.17.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -196,12 +196,12 @@ packages:
     source: hosted
     version: "0.18.2+1"
   flutter_lints:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_riverpod:
     dependency: transitive
     description:
@@ -297,7 +297,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   logging:
     dependency: transitive
     description:
@@ -353,7 +353,7 @@ packages:
       name: pedantic_mono
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.2"
   pool:
     dependency: transitive
     description:
@@ -507,5 +507,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "38.0.0"
+    version: "46.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.1"
+    version: "4.6.0"
   args:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   build_config:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.0.9"
   build_runner:
     dependency: "direct dev"
     description:
@@ -161,7 +161,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   fake_async:
     dependency: transitive
     description:
@@ -220,14 +220,14 @@ packages:
       name: freezed
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "2.1.0+1"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -407,7 +407,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,14 +49,14 @@ packages:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.8"
+    version: "2.2.0"
   build_runner_core:
     dependency: transitive
     description:
@@ -290,7 +290,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "4.6.0"
   lints:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -208,7 +208,7 @@ packages:
       name: flutter_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -255,7 +255,7 @@ packages:
       name: hooks_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   http_multi_server:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
   pedantic_mono: ^1.19.2
   freezed_annotation: ^2.1.0
-  flutter_hooks: ^0.18.2+1
+  flutter_hooks: ^0.18.5+1
   hooks_riverpod: ^1.0.3
 
   cupertino_icons: ^1.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   pedantic_mono: ^1.19.2
-  freezed_annotation: ^1.1.0
+  freezed_annotation: ^2.1.0
   flutter_hooks: ^0.18.2+1
   hooks_riverpod: ^1.0.3
 
@@ -24,7 +24,7 @@ dev_dependencies:
     sdk: flutter
 
   build_runner: ^2.2.0
-  freezed: ^1.1.1
+  freezed: ^2.1.0+1
 
 flutter:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  pedantic_mono: ^1.17.0
+  pedantic_mono: ^1.19.2
   freezed_annotation: ^1.1.0
   flutter_hooks: ^0.18.2+1
   hooks_riverpod: ^1.0.3
@@ -24,7 +24,6 @@ dev_dependencies:
     sdk: flutter
 
   build_runner: ^2.1.8
-  flutter_lints: ^1.0.0
   freezed: ^1.1.1
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   pedantic_mono: ^1.19.2
   freezed_annotation: ^2.1.0
   flutter_hooks: ^0.18.5+1
-  hooks_riverpod: ^1.0.3
+  hooks_riverpod: ^1.0.4
 
   cupertino_icons: ^1.0.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.1.8
+  build_runner: ^2.2.0
   freezed: ^1.1.1
 
 flutter:


### PR DESCRIPTION
## 🌈 Summary

- Migrate using packages to latest version

## 🎯 Details

- Update `pedantic_mono` to `1.19.2`
- Update `build_runner` to `2.2.0`
- Update `freezed` and `freezed_annotation` to `2.1.0(+1)`
- Update `flutter_hooks` to `0.18.5+1`
- Update `hooks_riverpod` to `1.0.4`