### PR TITLE
Migrate flutter and packages

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.3.1-stable
+flutter 3.3.9-stable

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -148,13 +148,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.4"
   dart_style:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -528,5 +528,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.18.5 <3.0.0"
   flutter: ">=3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -367,7 +367,7 @@ packages:
       name: pedantic_mono
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.2"
+    version: "1.20.0"
   pool:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -201,7 +201,7 @@ packages:
       name: flutter_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.1.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -248,7 +248,7 @@ packages:
       name: hooks_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.1.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -388,7 +388,7 @@ packages:
       name: riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "2.1.1"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "50.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "5.2.0"
   args:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   build_config:
     dependency: transitive
     description:
@@ -63,14 +63,14 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.1.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.2"
   build_runner_core:
     dependency: transitive
     description:
@@ -126,7 +126,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.3.0"
   collection:
     dependency: transitive
     description:
@@ -161,7 +161,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   fake_async:
     dependency: transitive
     description:
@@ -220,21 +220,21 @@ packages:
       name: freezed
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0+1"
+    version: "2.3.0"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "3.2.0"
   glob:
     dependency: transitive
     description:
@@ -421,7 +421,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.6"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=2.18.5 <3.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.2.0
+  build_runner: ^2.3.2
   freezed: ^2.3.0
   import_sorter: ^4.6.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,6 @@ dependencies:
   hooks_riverpod: ^1.0.4
   intersperse: ^2.0.0
 
-  cupertino_icons: ^1.0.2
-
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   pedantic_mono: ^1.20.0
   freezed_annotation: ^2.2.0
   flutter_hooks: ^0.18.5+1
-  hooks_riverpod: ^1.0.4
+  hooks_riverpod: ^2.1.1
   intersperse: ^2.0.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   pedantic_mono: ^1.20.0
-  freezed_annotation: ^2.1.0
+  freezed_annotation: ^2.2.0
   flutter_hooks: ^0.18.5+1
   hooks_riverpod: ^1.0.4
   intersperse: ^2.0.0
@@ -25,7 +25,7 @@ dev_dependencies:
     sdk: flutter
 
   build_runner: ^2.2.0
-  freezed: ^2.1.0+1
+  freezed: ^2.3.0
   import_sorter: ^4.6.0
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  pedantic_mono: ^1.19.2
+  pedantic_mono: ^1.20.0
   freezed_annotation: ^2.1.0
   flutter_hooks: ^0.18.5+1
   hooks_riverpod: ^1.0.4


### PR DESCRIPTION
## 🌈 Summary

- Update Flutter to 3.3.9
- Update Dart to 2.18.5
- Update packages

## 🎯 Details

- Modify `.tool-versions`
- Modify `pubspec.yaml`
  - `pedantic_mono`
  - `freezed`
  - `build_runner`
  - `hooks_riverpod`
  - Remove `cupertino_icons`