### PR TITLE
`ListViewModel` を `riverpod_annotation` で実装

### DIFF
--- a/lib/list_view/screen/list_view_screen.dart
+++ b/lib/list_view/screen/list_view_screen.dart
@@ -26,8 +26,8 @@ class ListViewScreen extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(listViewModel);
-    final notifier = ref.watch(listViewModel.notifier);
+    final state = ref.watch(listViewModelProvider);
+    final notifier = ref.watch(listViewModelProvider.notifier);
 
     final theme = Theme.of(context).textTheme;
 

--- a/lib/list_view/view_model/list_view_model.dart
+++ b/lib/list_view/view_model/list_view_model.dart
@@ -1,18 +1,18 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
-import 'package:hooks_riverpod/hooks_riverpod.dart';
-
 import 'package:dismantling/list_view/components/list_state.dart';
 import 'package:dismantling/list_view/model/list_view_constructor_type.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-final listViewModel =
-    StateNotifierProvider.autoDispose<_ListViewModel, ListState>(
-  (ref) => _ListViewModel(),
-);
+part 'list_view_model.g.dart';
 
-class _ListViewModel extends StateNotifier<ListState> {
-  _ListViewModel() : super(ListState.empty());
+@riverpod
+class ListViewModel extends _$ListViewModel {
+  @override
+  ListState build() {
+    return ListState.empty();
+  }
 
   void itemCountUpdated(int itemCount) {
     state = state.itemCountUpdated(itemCount);

--- a/lib/list_view/view_model/list_view_model.g.dart
+++ b/lib/list_view/view_model/list_view_model.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'list_view_model.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$listViewModelHash() => r'337c48ece5416fc782f30fbcb6f18a53d25aedc2';
+
+/// See also [ListViewModel].
+@ProviderFor(ListViewModel)
+final listViewModelProvider =
+    AutoDisposeNotifierProvider<ListViewModel, ListState>.internal(
+      ListViewModel.new,
+      name: r'listViewModelProvider',
+      debugGetCreateSourceHash:
+          const bool.fromEnvironment('dart.vm.product')
+              ? null
+              : _$listViewModelHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$ListViewModel = AutoDisposeNotifier<ListState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package


### PR DESCRIPTION
## 🍁 概要

- `ListViewModel` の生成において、 `@riverpod` を利用するように変更